### PR TITLE
Update dependencies and CI for compatibility audit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['18', '20']
+        node-version: ['18', '20', '22']
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the LDF VS Code Extension will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2025-12-29
+
+### Added
+- **Node.js 22 Support** - Added Node.js 22 to CI test matrix
+
+### Changed
+- **TypeScript 5.5** - Updated TypeScript from ^5.0.0 to ^5.5.0 for improved type checking and ES2023 features
+- Version number aligned with LDF CLI v1.2.0
+
+---
+
 ## [1.1.1] - 2025-12-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ldf-vscode",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ldf-vscode",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "js-yaml": "^4.1.0"
@@ -23,7 +23,7 @@
         "esbuild": "^0.27.2",
         "eslint": "^8.0.0",
         "mocha": "^11.7.5",
-        "typescript": "^5.0.0"
+        "typescript": "^5.5.0"
       },
       "engines": {
         "vscode": "^1.85.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ldf-vscode",
   "displayName": "LDF - Spec-Driven Development",
   "description": "Visual tools for LDF (LLM Development Framework) spec-driven development workflow",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "publisher": "llmdotinfo",
   "license": "MIT",
   "icon": "images/ldf-icon.png",
@@ -376,7 +376,7 @@
     "esbuild": "^0.27.2",
     "eslint": "^8.0.0",
     "mocha": "^11.7.5",
-    "typescript": "^5.0.0"
+    "typescript": "^5.5.0"
   },
   "dependencies": {
     "js-yaml": "^4.1.0"


### PR DESCRIPTION
## Summary
- Bump TypeScript to ^5.5.0 (resolves to 5.9.3)
- Update GitHub Actions to Node 22
- Regenerate package-lock.json

## Test plan
- [x] npm run compile passes
- [x] 86 tests passing
- [ ] CI validates on Node 22